### PR TITLE
added accepted Types to getEntity

### DIFF
--- a/library/Mvp.Xml/XInclude/XIncludingReader.cs
+++ b/library/Mvp.Xml/XInclude/XIncludingReader.cs
@@ -1597,7 +1597,9 @@ namespace Mvp.Xml.XInclude
 				object resource;
 				try
 				{
-					resource = xmlResolver.GetEntity(includeLocation, null, null);
+					resource = xmlResolver.GetEntity(includeLocation, null, typeof(Stream))
+						?? xmlResolver.GetEntity(includeLocation, null, typeof(TextReader))
+						?? xmlResolver.GetEntity(includeLocation, null, typeof(XmlReader));
 				}
 				catch (Exception e)
 				{


### PR DESCRIPTION
From the [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.xml.xmlresolver.getentity?view=net-7.0#returns) an resolver may return `null` if no `ofObjectToReturn` is provided.

not sure if the priority I used is the best.
- Stream
- TextReader
- XmlReader